### PR TITLE
Fix Windows 7 crash

### DIFF
--- a/layout/pattern.go
+++ b/layout/pattern.go
@@ -43,7 +43,7 @@ func getCaller() *caller {
 
 	// TODO feels nasty?
 	dir, fn := filepath.Split(file)
-	bits := strings.Split(dir, string(filepath.Separator))
+	bits := strings.Split(dir, "/")
 	pkg := bits[len(bits)-2]
 
 	if ok {


### PR DESCRIPTION
runtime.Caller returns filename with forward slashes so split with filepath.Separator in Windows 7 returns array with 1 item and program panic on line 47. 