### PR TITLE
add instruction to set customizable pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ pattern format similar to log4j:
 | %p   | Priority - the log level
 | %r   | ms since logger was created
 
+In order to set customizable pattern, you need to import "github.com/ian-kent/go-log/layout" using this:
+```
+import "github.com/ian-kent/go-log/layout"
+```
+
 ### Logger inheritance
 
 Loggers are namespaced with a ```.```, following similar rules to Log4j.

--- a/layout/pattern.go
+++ b/layout/pattern.go
@@ -47,7 +47,7 @@ func Pattern(pattern string) *patternLayout {
 }
 
 func getCaller() *caller {
-	pc, file, line, ok := runtime.Caller(2)
+	pc, file, line, ok := runtime.Caller(6)
 
 	// TODO feels nasty?
 	dir, fn := filepath.Split(file)


### PR DESCRIPTION
Old readme is misleading here. I was thinking Pattern is a method provided in the layout object returned from appender.Layout(). Actually it's provided in layout package.