### PR TITLE
Issue 009: Wrong File/Line from logger.Debug()

### DIFF
--- a/layout/pattern.go
+++ b/layout/pattern.go
@@ -47,7 +47,7 @@ func Pattern(pattern string) *patternLayout {
 }
 
 func getCaller() *caller {
-	pc, file, line, ok := runtime.Caller(2)
+	pc, file, line, ok := runtime.Caller(6)
 
 	// TODO feels nasty?
 	dir, fn := filepath.Split(file)


### PR DESCRIPTION
logger.Debug(x) -- or other logger entry function --
    calls logger.Log, which
    calls logger.Write, which
    calls appender.Write, which
    calls layout.Format, which
    calls layout.getCaller, which
    calls runtime.Caller.

Therefore the correct number of stack frames to ascend to get to
the caller of Debug -- or other logger entry function -- is 6.

See https://github.com/ian-kent/go-log/issues/9

See also https://golang.org/pkg/runtime/#Caller

This code reproduces the bug:

```go
package main

import(
    "github.com/ian-kent/go-log/appenders"
    "github.com/ian-kent/go-log/layout"
    "github.com/ian-kent/go-log/log"
)

func main() {
    logger := log.Logger()
    logger.SetLevel(log.Stol("DEBUG"))
    appender := appenders.RollingFile("sample.log", true)
    appender.MaxFileSize = 1024
    appender.SetLayout(layout.Pattern("%p %l %m "))
    logger.SetAppender(appender)
    logger.Debug("Reading configuration")
}
```

Result of runtime.Caller(n) in pattern.go for 0 >= n >= 7:

Caller(0): DEBUG layout/pattern.go:50 Reading configuration
Caller(1): DEBUG layout/pattern.go:70 Reading configuration
Caller(2): DEBUG appenders/rollingfile.go:51 Reading configuration
Caller(3): DEBUG logger/logger.go:129 Reading configuration
Caller(4): DEBUG logger/logger.go:154 Reading configuration
Caller(5): DEBUG logger/logger.go:213 Reading configuration
Caller(6): DEBUG go-log/bug009.go:16 Reading configuration
Caller(7): DEBUG runtime/proc.go:185 Reading configuration